### PR TITLE
Start to address issue #4.

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,5 +46,18 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.jimfs</groupId>
+            <artifactId>jimfs</artifactId>
+            <version>1.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.4</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/common/src/test/java/edu/emory/mathcs/nlp/common/util/IOUtilsTest.java
+++ b/common/src/test/java/edu/emory/mathcs/nlp/common/util/IOUtilsTest.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2015, Emory University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.emory.mathcs.nlp.common.util;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import org.junit.Test;
+import org.tukaani.xz.LZMA2Options;
+import org.tukaani.xz.XZOutputStream;
+
+import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.GZIPOutputStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+/**
+ *
+ */
+public class IOUtilsTest {
+
+    private static final String THIS_IS_THE_CEREAL_SHOT_FROM_GUNS = "This is the cereal shot from guns.\n";
+
+    @Test
+    public void fileNonStdFileSystem() throws Exception {
+        FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
+        Path testFile = fs.getPath("/foo.txt");
+        try (Writer writer = Files.newBufferedWriter(testFile)) {
+            writer.write(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS);
+        }
+
+        try (InputStream is = IOUtils.createArtifactInputStream(testFile)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        String uri = testFile.toUri().toString();
+        try (InputStream is = IOUtils.createArtifactInputStream(uri)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        Path testFilexz = fs.getPath("/foo.txt.xz");
+        try (Writer writer = new OutputStreamWriter(new XZOutputStream(Files.newOutputStream(testFilexz), new LZMA2Options()), UTF_8)) {
+            writer.write(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS);
+        }
+
+        try (InputStream is = IOUtils.createArtifactInputStream(testFilexz)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        uri = testFilexz.toUri().toString();
+        try (InputStream is = IOUtils.createArtifactInputStream(uri)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        Path testFilegz = fs.getPath("/foo.txt.gz");
+        try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(Files.newOutputStream(testFilegz)), UTF_8)) {
+            writer.write(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS);
+        }
+
+        try (InputStream is = IOUtils.createArtifactInputStream(testFilegz)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        uri = testFilegz.toUri().toString();
+        try (InputStream is = IOUtils.createArtifactInputStream(uri)) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        // test plain old file system
+        try (InputStream is = IOUtils.createArtifactInputStream("src/test/resources/a/test/some.txt")) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+
+        // test classpath
+        try (InputStream is = IOUtils.createArtifactInputStream("a/test/some.txt")) {
+            String contents = org.apache.commons.io.IOUtils.toString(is, "utf-8");
+            assertEquals(THIS_IS_THE_CEREAL_SHOT_FROM_GUNS, contents);
+        }
+    }
+}

--- a/common/src/test/resources/a/test/some.txt
+++ b/common/src/test/resources/a/test/some.txt
@@ -1,0 +1,1 @@
+This is the cereal shot from guns.

--- a/common/src/test/resources/log4j.properties
+++ b/common/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.conversionPattern=%m%n

--- a/core/src/main/java/edu/emory/mathcs/nlp/bin/ModelReduce.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/bin/ModelReduce.java
@@ -15,10 +15,6 @@
  */
 package edu.emory.mathcs.nlp.bin;
 
-import java.io.InputStream;
-import java.io.ObjectInputStream;
-import java.util.List;
-
 import edu.emory.mathcs.nlp.common.util.BinUtils;
 import edu.emory.mathcs.nlp.common.util.FileUtils;
 import edu.emory.mathcs.nlp.common.util.IOUtils;
@@ -30,6 +26,11 @@ import edu.emory.mathcs.nlp.component.template.state.NLPState;
 import edu.emory.mathcs.nlp.component.template.train.OnlineTrainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.util.List;
 
 /**
  * @author Jinho D. Choi ({@code jinho.choi@emory.edu})
@@ -43,28 +44,44 @@ public class ModelReduce extends NLPTrain
 		OnlineTrainer<N,S> trainer = createOnlineTrainer();
 		
 		List<String> developFiles  = FileUtils.getFileList(develop_path, develop_ext);
-		GlobalLexica<N> lexica = trainer.createGlobalLexica(IOUtils.createFileInputStream(configuration_file));
-		
+		GlobalLexica<N> lexica;
+		try (InputStream lexicaStream = IOUtils.createFileInputStream(configuration_file)) {
+			lexica = trainer.createGlobalLexica(lexicaStream);
+		} catch (IOException e) {
+			LOG.error("Failed to read lexica from " + configuration_file, e);
+			throw new RuntimeException("Failed to read lexica", e);
+		}
+
+
 		LOG.info("Loading the model");
-		OnlineComponent<N,S> component = readComponent(IOUtils.createFileInputStream(previous_model_file), IOUtils.createFileInputStream(configuration_file));
+		OnlineComponent<N,S> component = null;
+		try {
+			component = readComponent(previous_model_file, configuration_file);
+		} catch (IOException e) {
+			LOG.error(String.format("Failed to read model %s or configuration %s", previous_model_file == null ? "none" : previous_model_file, configuration_file),
+					e);
+			throw new RuntimeException(String.format("Failed to read model %s or configuration %s", previous_model_file == null ? "none" : previous_model_file, configuration_file),
+					e);
+		}
 		TSVReader<N> reader = trainer.createTSVReader(component.getConfiguration().getReaderFieldMap());
 		trainer.reduceModel(reader, developFiles, component, lexica, previous_model_file, model_file);
 	}
 	
 	@SuppressWarnings("unchecked")
-	public <N extends AbstractNLPNode<N>, S extends NLPState<N>>OnlineComponent<N,S> readComponent(InputStream model, InputStream config)
-	{
-		ObjectInputStream oin = IOUtils.createObjectXZBufferedInputStream(model);
-		OnlineComponent<N,S> component = null;
-		
-		try
-		{
-			component = (OnlineComponent<N,S>)oin.readObject();
-			component.setConfiguration(config);
-			oin.close();
+	public <N extends AbstractNLPNode<N>, S extends NLPState<N>>OnlineComponent<N,S> readComponent(String modelPathname, String configPathname) throws IOException {
+		OnlineComponent<N, S> component;
+		try (ObjectInputStream oin = IOUtils.createArtifactObjectInputStream(modelPathname)) {
+			component = (OnlineComponent<N, S>) oin.readObject();
+			try (InputStream configStream = IOUtils.createArtifactInputStream(configPathname)) {
+				component.setConfiguration(configStream);
+			}
+		} catch (ClassNotFoundException e) {
+			LOG.error(String.format("Failed to read serialized configuration %s or model %s",
+					configPathname, modelPathname),
+					e);
+			throw new RuntimeException("Failed to read serialized configuration or model", e);
 		}
-		catch (Exception e) {e.printStackTrace();}
-		
+
 		return component;
 	}
 	

--- a/core/src/main/java/edu/emory/mathcs/nlp/bin/NLPTrain.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/bin/NLPTrain.java
@@ -15,6 +15,7 @@
  */
 package edu.emory.mathcs.nlp.bin;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
 import java.util.List;
@@ -74,7 +75,11 @@ public class NLPTrain
 		NLPMode m = NLPMode.valueOf(mode);
 		
 		if (cv > 1) trainer.crossValidate(m, trainFiles, configuration_file, model_file, previous_model_file, cv);
-		else		trainer.train(m, trainFiles, developFiles, configuration_file, model_file, previous_model_file);
+		else try {
+			trainer.train(m, trainFiles, developFiles, configuration_file, model_file, previous_model_file);
+		} catch (IOException e) {
+			throw new RuntimeException("IOException setting up components", e);
+		}
 	}
 	
 	public <N extends AbstractNLPNode<N>, S extends NLPState<N>>OnlineTrainer<N,S> createOnlineTrainer()
@@ -107,7 +112,11 @@ public class NLPTrain
 			@Override
 			public GlobalLexica<N> createGlobalLexica(InputStream config)
 			{
-				return new GlobalLexica<>(config);
+				try {
+					return new GlobalLexica<>(config);
+				} catch (IOException e) {
+					throw new RuntimeException("Failed to create lexica due to problem reading something", e);
+				}
 			}
 		};
 	}

--- a/core/src/main/java/edu/emory/mathcs/nlp/component/template/lexicon/GlobalLexica.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/component/template/lexicon/GlobalLexica.java
@@ -85,19 +85,19 @@ public class GlobalLexica<N extends AbstractNLPNode<N>> implements NLPComponent<
 	@SuppressWarnings("unchecked")
 	protected <T>GlobalLexicon<T> getGlobalLexicon(Element element, String message) throws IOException
 	{
-		if (element == null) return null;
-		LOG.info(message);
-		
+		if (element == null) {
+			return null;
+		}
 		String path = XMLUtils.getTrimmedTextContent(element);
-		ObjectInputStream oin = IOUtils.createArtifactObjectInputStream(path);
-		Field field = Field.valueOf(XMLUtils.getTrimmedAttribute(element, FIELD));
-		String name = XMLUtils.getTrimmedAttribute(element, NAME);
-		T lexicon = null;
-		
-		try
-		{
-			lexicon = (T)oin.readObject();
-			oin.close();
+		T lexicon;
+		Field field;
+		String name;
+		try (ObjectInputStream oin = IOUtils.createArtifactObjectInputStream(path)) {
+			field = Field.valueOf(XMLUtils.getTrimmedAttribute(element, FIELD));
+			name = XMLUtils.getTrimmedAttribute(element, NAME);
+			LOG.info("{} {} {}", message, name, path);
+
+			lexicon = (T) oin.readObject();
 		}
 		catch (IOException e) {
 			throw e;

--- a/core/src/main/java/edu/emory/mathcs/nlp/component/template/train/OnlineTrainer.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/component/template/train/OnlineTrainer.java
@@ -111,6 +111,7 @@ public abstract class OnlineTrainer<N extends AbstractNLPNode<N>, S extends NLPS
 	}
 	
 	public OnlineComponent<N,S> createComponent(NLPMode mode, String configPathname, String name) throws IOException {
+		LOG.info("Reading configuration " + configPathname);
 		if (name != null) {
 			LOG.warn("Name not implemented for OnlineComponent. Input name - " + name + " will be ignored.");
 		}

--- a/core/src/main/java/edu/emory/mathcs/nlp/component/template/train/OnlineTrainer.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/component/template/train/OnlineTrainer.java
@@ -37,7 +37,6 @@ import edu.emory.mathcs.nlp.common.collection.tuple.DoubleIntPair;
 import edu.emory.mathcs.nlp.common.collection.tuple.ObjectDoublePair;
 import edu.emory.mathcs.nlp.common.collection.tuple.Pair;
 import edu.emory.mathcs.nlp.common.random.XORShiftRandom;
-import edu.emory.mathcs.nlp.common.util.BinUtils;
 import edu.emory.mathcs.nlp.common.util.FileUtils;
 import edu.emory.mathcs.nlp.common.util.IOUtils;
 import edu.emory.mathcs.nlp.common.util.XMLUtils;
@@ -65,27 +64,33 @@ public abstract class OnlineTrainer<N extends AbstractNLPNode<N>, S extends NLPS
 //	=================================== COMPONENT ===================================
 	
 	@SuppressWarnings("unchecked")
-	public OnlineComponent<N,S> initComponent(NLPMode mode, InputStream configStream, InputStream previousModelStream, String name)
-	{
-		OnlineComponent<N,S> component = null;
-		NLPConfig<N> configuration = null;
+	public OnlineComponent<N,S> initComponent(NLPMode mode, String configPathname, String previousModelPathname, String name) throws IOException {
+		OnlineComponent<N,S> component;
+		NLPConfig<N> configuration;
 		
-		if (previousModelStream != null)
+		if (previousModelPathname != null)
 		{
 			LOG.info("Loading the previous model");
-			ObjectInputStream oin = IOUtils.createObjectXZBufferedInputStream(previousModelStream);
-			
-			try
-			{
+			ObjectInputStream oin;
+			try {
+				oin = IOUtils.createArtifactObjectInputStream(previousModelPathname);
+			} catch (IOException e) {
+				throw new RuntimeException("Failed to open previous model " + previousModelPathname, e);
+			}
+
+			try (InputStream configStream = IOUtils.createArtifactObjectInputStream(configPathname)) {
 				component = (OnlineComponent<N,S>)oin.readObject();
 				configuration = component.setConfiguration(configStream);
 				oin.close();
+			} catch (IOException | ClassNotFoundException e) {
+				throw new RuntimeException("Failed to setup component " + name, e);
 			}
-			catch (Exception e) {e.printStackTrace();}
+
+
 		}
 		else
 		{
-			component = createComponent(mode, configStream, name);
+			component = createComponent(mode, configPathname, name);
 			configuration = component.getConfiguration();
 		}
 		
@@ -105,15 +110,16 @@ public abstract class OnlineTrainer<N extends AbstractNLPNode<N>, S extends NLPS
 		return component;
 	}
 	
-	public OnlineComponent<N,S> createComponent(NLPMode mode, InputStream config, String name)
-	{
+	public OnlineComponent<N,S> createComponent(NLPMode mode, String configPathname, String name) throws IOException {
 		if (name != null) {
 			LOG.warn("Name not implemented for OnlineComponent. Input name - " + name + " will be ignored.");
 		}
-		return createComponent(mode, config);
+		try (InputStream configStream = IOUtils.createArtifactInputStream(configPathname)) {
+			return createComponent(mode, configStream);
+		}
 	}
 	
-	public abstract OnlineComponent<N,S> createComponent(NLPMode mode, InputStream config);
+	public abstract OnlineComponent<N,S> createComponent(NLPMode mode, InputStream configStream);
 	public abstract TSVReader<N> createTSVReader(Object2IntMap<String> map);
 	public abstract GlobalLexica<N> createGlobalLexica(InputStream config);
 	
@@ -190,21 +196,27 @@ public abstract class OnlineTrainer<N extends AbstractNLPNode<N>, S extends NLPS
 		@Override
 		public Double call()
 		{
-			return train(mode, trainFiles, developFiles, configurationFile, modelFile, previousModelFile);
+			try {
+				return train(mode, trainFiles, developFiles, configurationFile, modelFile, previousModelFile);
+			} catch (IOException e) {
+				LOG.error("IO exception setting up components", e);
+				throw new RuntimeException("IO exception setting up components", e);
+			}
 		}
 	}
 	
-	public double train(NLPMode mode, List<String> trainFiles, List<String> developFiles, String configurationFile, String modelFile, String previousModelFile)
-	{
+	public double train(NLPMode mode, List<String> trainFiles, List<String> developFiles, String configurationFile, String modelFile, String previousModelFile) throws IOException {
 		return train(mode, trainFiles, developFiles, configurationFile, modelFile, previousModelFile, 0);
 	}
 	
-	public double train(NLPMode mode, List<String> trainFiles, List<String> developFiles, String configurationFile, String modelFile, String previousModelFile, int index)
-	{
-		InputStream previousModelStream = (previousModelFile != null) ? IOUtils.createFileInputStream(previousModelFile) : null;
-		GlobalLexica<N> lexica = createGlobalLexica(IOUtils.createFileInputStream(configurationFile));
+	public double train(NLPMode mode, List<String> trainFiles, List<String> developFiles, String configurationFile, String modelFile, String previousModelFile, int index) throws IOException {
+		GlobalLexica<N> lexica;
+		try (InputStream configStream = IOUtils.createFileInputStream(configurationFile)) {
+			lexica = createGlobalLexica(configStream);
+		}
+
 		String name = (modelFile != null) ? FileUtils.getBaseName(modelFile) : null;
-		OnlineComponent<N,S> component = initComponent(mode, IOUtils.createFileInputStream(configurationFile), previousModelStream, name);
+		OnlineComponent<N,S> component = initComponent(mode, configurationFile, previousModelFile, name);
 		TSVReader<N> reader = createTSVReader(component.getConfiguration().getReaderFieldMap());
 		ObjectDoublePair<OnlineComponent<N,S>> p = null;
 		

--- a/core/src/main/java/edu/emory/mathcs/nlp/zzz/CaseCollect.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/zzz/CaseCollect.java
@@ -104,7 +104,7 @@ public class CaseCollect
 		final String INPUT_FILE  = args[0];
 		final String OUTPUT_FILE = args[0]+"."+args[1]+"."+args[2]+".xz";
 		
-		ObjectInputStream  in  = IOUtils.createObjectXZBufferedInputStream (INPUT_FILE);
+		ObjectInputStream  in  = IOUtils.createArtifactObjectInputStream(INPUT_FILE);
 		ObjectOutputStream out = IOUtils.createObjectXZBufferedOutputStream(OUTPUT_FILE);
 		int cutoff = Integer.parseInt(args[1]);
 		double threshold = Double.parseDouble(args[2]);

--- a/core/src/main/java/edu/emory/mathcs/nlp/zzz/Radiology.java
+++ b/core/src/main/java/edu/emory/mathcs/nlp/zzz/Radiology.java
@@ -96,7 +96,7 @@ public class Radiology
 	@SuppressWarnings("unchecked")
 	Set<String> getStopWordSet(String filename) throws Exception
 	{
-		ObjectInputStream in = IOUtils.createObjectXZBufferedInputStream(filename);
+		ObjectInputStream in = IOUtils.createArtifactObjectInputStream(filename);
 		Set<String> set = (Set<String>)in.readObject();
 		return set;
 	}

--- a/core/src/test/resources/log4j.properties
+++ b/core/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.conversionPattern=%m%n

--- a/morphology/pom.xml
+++ b/morphology/pom.xml
@@ -17,5 +17,10 @@
             <artifactId>nlp4j-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/morphology/src/test/resources/log4j.properties
+++ b/morphology/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.conversionPattern=%m%n

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/bin/NLPDecode.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/bin/NLPDecode.java
@@ -15,6 +15,7 @@
  */
 package edu.emory.mathcs.nlp.bin;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
@@ -52,8 +53,12 @@ public class NLPDecode
 		BinUtils.initArgs(args, this);
 		List<String> filelist = FileUtils.getFileList(input_path, input_ext, false);
 		Collections.sort(filelist);
-		
-		decoder = new NLPDecoder(IOUtils.createFileInputStream(configuration_file));
+
+		try {
+			decoder = new NLPDecoder(IOUtils.createFileInputStream(configuration_file));
+		} catch (IOException e) {
+			throw new RuntimeException("Error opening data file", e);
+		}
 		decoder.decode(filelist, output_ext, format, threads);
 	}
 	

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/AbstractNLPDecoder.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/AbstractNLPDecoder.java
@@ -82,27 +82,27 @@ public abstract class AbstractNLPDecoder<N extends AbstractNLPNode<N>>
 			throw new RuntimeException("Failed to initialize lexica due to problems reading something", e);
 		}
 
-		LOG.info("Loading tokenizer");
+		LOG.info("Loading tokenizer {}", language);
 		setTokenizer(NLPUtils.createTokenizer(language));
 		
 		if (decode_config.getPartOfSpeechTagging() != null)
 		{
-			LOG.info("Loading part-of-speech tagger");
+			LOG.info("Loading part-of-speech tagger {}", decode_config.getPartOfSpeechTagging());
 			components.add(NLPUtils.getComponent(decode_config.getPartOfSpeechTagging()));
 			
-			LOG.info("Loading morphological analyzer");
+			LOG.info("Loading morphological analyzer {}", language);
 			components.add(new MorphologicalAnalyzer<>(language));
 		}
 		
 		if (decode_config.getNamedEntityRecognition() != null)
 		{
-			LOG.info("Loading named entity recognizer");
+			LOG.info("Loading named entity recognizer {}", decode_config.getNamedEntityRecognition());
 			components.add(NLPUtils.getComponent(decode_config.getNamedEntityRecognition()));
 		}
 		
 		if (decode_config.getDependencyParsing() != null)
 		{
-			LOG.info("Loading dependency parser");
+			LOG.info("Loading dependency parser {}", decode_config.getDependencyParsing());
 			components.add(NLPUtils.getComponent(decode_config.getDependencyParsing()));
 		}
 		

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/AbstractNLPDecoder.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/AbstractNLPDecoder.java
@@ -63,31 +63,32 @@ public abstract class AbstractNLPDecoder<N extends AbstractNLPNode<N>>
 	
 	public AbstractNLPDecoder() {}
 	
-	public AbstractNLPDecoder(DecodeConfig config)
-	{
+	public AbstractNLPDecoder(DecodeConfig config) throws IOException {
 		init(config);
 	}
 	
-	public AbstractNLPDecoder(InputStream configuration)
-	{
+	public AbstractNLPDecoder(InputStream configuration) throws IOException {
 		init(new DecodeConfig(configuration));
 	}
 	
-	public void init(DecodeConfig config)
-	{
+	public void init(DecodeConfig config) throws IOException {
 		List<NLPComponent<N>> components = new ArrayList<>();
 		Language language = config.getLanguage();
 		decode_config = config;
-		
-		components.add(new GlobalLexica<>(decode_config.getDocumentElement()));
-		
+
+		try {
+			components.add(new GlobalLexica<>(decode_config.getDocumentElement()));
+		} catch (IOException e) {
+			throw new RuntimeException("Failed to initialize lexica due to problems reading something", e);
+		}
+
 		LOG.info("Loading tokenizer");
 		setTokenizer(NLPUtils.createTokenizer(language));
 		
 		if (decode_config.getPartOfSpeechTagging() != null)
 		{
 			LOG.info("Loading part-of-speech tagger");
-			components.add(NLPUtils.getComponent(IOUtils.getInputStream(decode_config.getPartOfSpeechTagging())));
+			components.add(NLPUtils.getComponent(decode_config.getPartOfSpeechTagging()));
 			
 			LOG.info("Loading morphological analyzer");
 			components.add(new MorphologicalAnalyzer<>(language));
@@ -96,13 +97,13 @@ public abstract class AbstractNLPDecoder<N extends AbstractNLPNode<N>>
 		if (decode_config.getNamedEntityRecognition() != null)
 		{
 			LOG.info("Loading named entity recognizer");
-			components.add(NLPUtils.getComponent(IOUtils.getInputStream(decode_config.getNamedEntityRecognition())));
+			components.add(NLPUtils.getComponent(decode_config.getNamedEntityRecognition()));
 		}
 		
 		if (decode_config.getDependencyParsing() != null)
 		{
 			LOG.info("Loading dependency parser");
-			components.add(NLPUtils.getComponent(IOUtils.getInputStream(decode_config.getDependencyParsing())));
+			components.add(NLPUtils.getComponent(decode_config.getDependencyParsing()));
 		}
 		
 //		if (decode_config.getSemanticRoleLabeling() != null)

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/NLPDecoder.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/NLPDecoder.java
@@ -15,6 +15,7 @@
  */
 package edu.emory.mathcs.nlp.decode;
 
+import java.io.IOException;
 import java.io.InputStream;
 
 import edu.emory.mathcs.nlp.component.template.node.NLPNode;
@@ -26,13 +27,11 @@ public class NLPDecoder extends AbstractNLPDecoder<NLPNode>
 {
 	public NLPDecoder() {super();}
 	
-	public NLPDecoder(DecodeConfig config)
-	{
+	public NLPDecoder(DecodeConfig config) throws IOException {
 		super(config);
 	}
 	
-	public NLPDecoder(InputStream configuration)
-	{
+	public NLPDecoder(InputStream configuration) throws IOException {
 		super(new DecodeConfig(configuration));
 	}
 	

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/NLPUtils.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/decode/NLPUtils.java
@@ -15,6 +15,7 @@
  */
 package edu.emory.mathcs.nlp.decode;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 
@@ -30,12 +31,15 @@ import edu.emory.mathcs.nlp.component.template.state.NLPState;
 import edu.emory.mathcs.nlp.component.template.util.NLPFlag;
 import edu.emory.mathcs.nlp.tokenization.EnglishTokenizer;
 import edu.emory.mathcs.nlp.tokenization.Tokenizer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jinho D. Choi ({@code jinho.choi@emory.edu})
  */
 public class NLPUtils
 {
+	static private final Logger LOG = LoggerFactory.getLogger(NLPUtils.class);
 	static public String FEAT_POS_2ND   = "pos2";
 	static public String FEAT_PREDICATE = "pred";
 
@@ -50,9 +54,8 @@ public class NLPUtils
 	}
 	
 	@SuppressWarnings("unchecked")
-	static public <N extends AbstractNLPNode<N>,S extends NLPState<N>>NLPComponent<N> getComponent(InputStream in)
-	{
-		ObjectInputStream oin = IOUtils.createObjectXZBufferedInputStream(in);
+	static public <N extends AbstractNLPNode<N>,S extends NLPState<N>>NLPComponent<N> getComponent(String inPath) throws IOException {
+		ObjectInputStream oin = IOUtils.createArtifactObjectInputStream(inPath);
 		OnlineComponent<N,S> component = null;
 		
 		try
@@ -61,7 +64,10 @@ public class NLPUtils
 			component.setFlag(NLPFlag.DECODE);
 			oin.close();
 		}
-		catch (Exception e) {e.printStackTrace();}
+		catch (Exception e) {
+			LOG.error("Failed to read " + inPath, e);
+			throw new RuntimeException("Failed to read " + inPath, e);
+		}
 
 		return component;
 	}

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/zzz/CSVSentiment.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/zzz/CSVSentiment.java
@@ -15,6 +15,7 @@
  */
 package edu.emory.mathcs.nlp.zzz;
 
+import java.io.IOException;
 import java.io.PrintStream;
 import java.util.List;
 
@@ -46,7 +47,11 @@ public class CSVSentiment
 	
 	public CSVSentiment(String configurationFile)
 	{
-		decode = new NLPDecoder(IOUtils.createFileInputStream(configurationFile));		
+		try {
+			decode = new NLPDecoder(IOUtils.createFileInputStream(configurationFile));
+		} catch (IOException e) {
+			throw new RuntimeException("Error opening data file", e);
+		}
 	}
 	
 	public void categorize(String inputFile) throws Exception

--- a/nlp4j/src/main/java/edu/emory/mathcs/nlp/zzz/TokenizeIt.java
+++ b/nlp4j/src/main/java/edu/emory/mathcs/nlp/zzz/TokenizeIt.java
@@ -16,6 +16,7 @@
 package edu.emory.mathcs.nlp.zzz;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -42,7 +43,11 @@ public class TokenizeIt
 	
 	public TokenizeIt(String configFile)
 	{
-		decoder   = new NLPDecoder(IOUtils.createFileInputStream(configFile));
+		try {
+			decoder   = new NLPDecoder(IOUtils.createFileInputStream(configFile));
+		} catch (IOException e) {
+			throw new RuntimeException("Error opening data file", e);
+		}
 		tokenizer = new EnglishTokenizer();
 	}
 	

--- a/tokenization/src/test/resources/log4j.properties
+++ b/tokenization/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=INFO, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.conversionPattern=%m%n


### PR DESCRIPTION
This is not ready to merge -- however, I wanted to give you a chance to object to the changes.

The approach I took has ended up resulting in a fair amount of fan-out of changes to APIs to accept String pathnames instead of InputStreams. I didn't want to get involved in sniffing bytes from files to decide upon decompression, and I preferred to make more things pass pathnames.

In the process, I removed some tendencies to leak open files and some tendencies to swallow exceptions or just print the backtraces.

If you hate any of this, please let me know. I could certainly chuck all these changes above IOUtils and implement format sniffing instead. To my taste, this is making the code better, but, as always, chacun a son gout.
