### PR TITLE
Make sure the english models are in the command assembly.

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -16,7 +16,6 @@
         <dependency>
             <groupId>edu.emory.mathcs.nlp</groupId>
             <artifactId>nlp4j-english</artifactId>
-            <scope>test</scope>
             <version>1.1.2</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
We want the English model jar to be incorporated in target/appassembler/bin, so that the commands actually work if they are applied to XML files that call for the usual resources. So switch the scope in 'cli' for that dependency to be the default scope.
