### PR TITLE
Make it easier for an application to avoid the XML descriptor 

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,7 @@
             <groupId>edu.emory.mathcs.nlp</groupId>
             <artifactId>nlp4j-english</artifactId>
             <scope>test</scope>
-            <version>1.1.2</version>
+            <version>1.1.3</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -41,7 +41,6 @@
             <version>2.4</version>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -67,4 +66,34 @@
             <artifactId>commons-csv</artifactId>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>2.10</version>
+                <executions>
+                    <!-- Allow us to have unit tests that work with the -->
+                    <execution>
+                        <id>unpack</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>edu.emory.mathcs.nlp</groupId>
+                                    <artifactId>nlp4j-english</artifactId>
+                                    <version>1.1.3</version>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/english</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/api/src/main/java/edu/emory/mathcs/nlp/common/util/IOUtils.java
+++ b/api/src/main/java/edu/emory/mathcs/nlp/common/util/IOUtils.java
@@ -366,6 +366,26 @@ public class IOUtils
 		return wrapStream(baseStream, pathname);
 	}
 
+	/**
+	 * Return a stream, set up to decompress as needed, for a resource found via classloading.
+	 * @param classpath the pathname of the resource.
+	 * @param classLoader the classloader to search. If {@code null}, this method uses
+	 *                    the thread context class loader.
+	 * @return the stream.
+	 * @throws IOException if something goes wrong.
+	 */
+	static public InputStream createArtifactInputStreamForClasspath(String classpath, ClassLoader classLoader) throws IOException {
+		if (classLoader == null) {
+			classLoader = Thread.currentThread().getContextClassLoader();
+		}
+		InputStream baseStream = classLoader.getResourceAsStream(classpath);
+		if (baseStream == null) {
+			throw new IOException(String.format("Could not find %s in provided class loader.",
+					classpath));
+		}
+		return wrapStream(baseStream, classpath);
+	}
+
 	static public InputStream createArtifactInputStream(Path path) throws IOException
 	{
 		String name = path.getFileName().toString();
@@ -392,6 +412,18 @@ public class IOUtils
 	 * @see #createArtifactInputStream(String)
 	 */
 	static public ObjectInputStream createArtifactObjectInputStream(String pathname) throws IOException
+	{
+		return new ObjectInputStream(createArtifactInputStream(pathname));
+	}
+
+	/**
+	 * Open an input stream that reads a {@link Path} in Serialized java format.
+	 * @param pathname the pathname.
+	 * @return the stream.
+	 * @throws IOException if something goes wrong.
+	 * @see #createArtifactInputStream(String)
+	 */
+	static public ObjectInputStream createArtifactObjectInputStream(Path pathname) throws IOException
 	{
 		return new ObjectInputStream(createArtifactInputStream(pathname));
 	}

--- a/api/src/main/java/edu/emory/mathcs/nlp/common/util/NLPUtils.java
+++ b/api/src/main/java/edu/emory/mathcs/nlp/common/util/NLPUtils.java
@@ -15,9 +15,11 @@
  */
 package edu.emory.mathcs.nlp.common.util;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.lang.reflect.Array;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
@@ -211,4 +213,61 @@ public class NLPUtils
 		
 		return graph;
 	}
+
+    /**
+     * Create a component from an object in a file system. Throw exceptions
+     * for errors reading the data.
+     * @param pathname the object's location.
+     * @param <N> The type of NLP node that this component processes.
+     * @param <S> State manager type.
+     * @return the object.
+     */
+    @SuppressWarnings("unchecked")
+    static public <N extends AbstractNLPNode<N>, S extends NLPState<N>> NLPComponent<N> getComponent(Path pathname) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream oin = IOUtils.createArtifactObjectInputStream(pathname)) {
+            OnlineComponent<N, S> component;
+            component = (OnlineComponent<N, S>) oin.readObject();
+            component.setFlag(NLPFlag.DECODE);
+            return component;
+        }
+    }
+
+    /**
+     * Create a component from an object found in the classpath. Throw exceptions
+     * for errors reading the data.
+     * @param classpath the object's location in the classpath.
+     * @param <N> The type of NLP node that this component processes.
+     * @param <S> State manager type.
+     * @return the object.
+     */
+    @SuppressWarnings("unchecked")
+    static public <N extends AbstractNLPNode<N>, S extends NLPState<N>> NLPComponent<N>
+    getComponentFromClasspath(String classpath, ClassLoader classLoader) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream oin = new ObjectInputStream(IOUtils.createArtifactInputStreamForClasspath(classpath, classLoader))) {
+            OnlineComponent<N, S> component;
+            component = (OnlineComponent<N, S>) oin.readObject();
+            component.setFlag(NLPFlag.DECODE);
+            return component;
+        }
+    }
+
+    /**
+     * Create a component from an object read from a stream. It is the caller's responsibility
+     * to arrange for any decompression.
+     * @param <N> The type of NLP node that this component processes.
+     * @param <S> State manager type.
+     * @param inputStream the stream containing the object.
+     * @return the object.
+     */
+    @SuppressWarnings("unchecked")
+    static public <N extends AbstractNLPNode<N>, S extends NLPState<N>> NLPComponent<N>
+    getComponentFromRawStream(InputStream inputStream) throws IOException, ClassNotFoundException {
+        try (ObjectInputStream oin = new ObjectInputStream(inputStream)) {
+            OnlineComponent<N, S> component;
+            component = (OnlineComponent<N, S>) oin.readObject();
+            component.setFlag(NLPFlag.DECODE);
+            return component;
+        }
+    }
+
 }

--- a/api/src/main/java/edu/emory/mathcs/nlp/decode/DecodeConfig.java
+++ b/api/src/main/java/edu/emory/mathcs/nlp/decode/DecodeConfig.java
@@ -23,6 +23,11 @@ import org.w3c.dom.Element;
 import java.io.InputStream;
 
 /**
+ * This class contains the specification of components to use in a decoder.
+ * It is usually initialized from an XML file, but may be initialized manually
+ * if an application prefers. It stores the names of models for the desired
+ * components as {@code String} values. By convention, these are interpreted
+ * as either a classpath reference or a URI that can be converted to a {@link java.nio.file.Path}.
  * @author Jinho D. Choi ({@code jinho.choi@emory.edu})
  */
 public class DecodeConfig extends NLPConfig<NLPNode>


### PR DESCRIPTION
@jdchoi77 Here's some changes that would neaten up integration for production applications. I could almost do what I want to do without this, but there's one missing public constructor. If it's not convenient for you to merge and release until you complete your 'real' work, I won't be hassling you; I can certainly wait.
